### PR TITLE
Fix union wrong casting

### DIFF
--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -241,19 +241,25 @@ fn comparison_binary_numeric_coercion(
         // start checking from Int64, that is the most inclusive integer type
         (Int64, _)
         | (_, Int64)
-        | (Int32, UInt32)
-        | (UInt32, Int32)
-        | (Int16, UInt32)
-        | (UInt32, Int16)
+        | (UInt64, Int8)
+        | (Int8, UInt64)
+        | (UInt64, Int16)
+        | (Int16, UInt64)
+        | (UInt64, Int32)
+        | (Int32, UInt64)
+        | (UInt32, Int8)
         | (Int8, UInt32)
-        | (UInt32, Int8) => Some(Int64),
+        | (UInt32, Int16)
+        | (Int16, UInt32)
+        | (UInt32, Int32)
+        | (Int32, UInt32) => Some(Int64),
         (UInt64, _) | (_, UInt64) => Some(UInt64),
         (Int32, _)
         | (_, Int32)
-        | (Int16, UInt16)
         | (UInt16, Int16)
-        | (Int8, UInt16)
-        | (UInt16, Int8) => Some(Int32),
+        | (Int16, UInt16)
+        | (UInt16, Int8)
+        | (Int8, UInt16) => Some(Int32),
         (UInt32, _) | (_, UInt32) => Some(UInt32),
         (Int16, _) | (_, Int16) | (Int8, UInt8) | (UInt8, Int8) => Some(Int16),
         (UInt16, _) | (_, UInt16) => Some(UInt16),

--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -238,13 +238,25 @@ fn comparison_binary_numeric_coercion(
         (_, Decimal128(_, _)) => get_comparison_common_decimal_type(rhs_type, lhs_type),
         (Float64, _) | (_, Float64) => Some(Float64),
         (_, Float32) | (Float32, _) => Some(Float32),
-        (Int64, _) | (_, Int64) => Some(Int64),
-        (Int32, _) | (_, Int32) => Some(Int32),
-        (Int16, _) | (_, Int16) => Some(Int16),
-        (Int8, _) | (_, Int8) => Some(Int8),
+        (Int64, _)
+        | (_, Int64)
+        | (Int32, UInt32)
+        | (UInt32, Int32)
+        | (Int16, UInt32)
+        | (UInt32, Int16)
+        | (Int8, UInt32)
+        | (UInt32, Int8) => Some(Int64),
         (UInt64, _) | (_, UInt64) => Some(UInt64),
+        (Int32, _)
+        | (_, Int32)
+        | (Int16, UInt16)
+        | (UInt16, Int16)
+        | (Int8, UInt16)
+        | (UInt16, Int8) => Some(Int32),
         (UInt32, _) | (_, UInt32) => Some(UInt32),
+        (Int16, _) | (_, Int16) | (Int8, UInt8) | (UInt8, Int8) => Some(Int16),
         (UInt16, _) | (_, UInt16) => Some(UInt16),
+        (Int8, _) | (_, Int8) => Some(Int8),
         (UInt8, _) | (_, UInt8) => Some(UInt8),
         _ => None,
     }

--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -238,7 +238,11 @@ fn comparison_binary_numeric_coercion(
         (_, Decimal128(_, _)) => get_comparison_common_decimal_type(rhs_type, lhs_type),
         (Float64, _) | (_, Float64) => Some(Float64),
         (_, Float32) | (Float32, _) => Some(Float32),
-        // start checking from Int64, that is the most inclusive integer type
+        // The following match arms encode the following logic: Given the two
+        // integral types, we choose the narrowest possible integral type that
+        // accommodates all values of both types. Note that some information
+        // loss is inevitable when we have a signed type and a `UInt64`, in
+        // which case we use `Int64`;i.e. the widest signed integral type.
         (Int64, _)
         | (_, Int64)
         | (UInt64, Int8)

--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -238,6 +238,7 @@ fn comparison_binary_numeric_coercion(
         (_, Decimal128(_, _)) => get_comparison_common_decimal_type(rhs_type, lhs_type),
         (Float64, _) | (_, Float64) => Some(Float64),
         (_, Float32) | (Float32, _) => Some(Float32),
+        // start checking from Int64, that is the most inclusive integer type
         (Int64, _)
         | (_, Int64)
         | (Int32, UInt32)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5212.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

When we try to use "UNION" on columns having differently signed or sized integer types, we get a cast error for some cases (explained in the issue), which can be handled accurately. 

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Previous casting matches are modified such that the resulting type of the column will be the smallest unit that will not cause to any error.

  | Int64 | Int32 | Int16 | Int8 | UInt64 | UInt32 | UInt16 | UInt8
-- | -- | -- | -- | -- | -- | -- | -- | --
Int64 | Int64 | Int64 | Int64 | Int64 | Int64 | Int64 | Int64 | Int64
Int32 | Int64 | Int32 | Int32 | Int32 | Int64 | Int64 | Int32 | Int32
Int16 | Int64 | Int32 | Int16 | Int16 | Int64 | Int64 | Int32 | Int16
Int8 | Int64 | Int32 | Int16 | Int8 | Int64 | Int64 | Int32 | Int16
UInt64 | Int64 | Int64 | Int64 | Int64 | UInt64 | UInt64 | UInt64 | UInt64
UInt32 | Int64 | Int64 | Int64 | Int64 | UInt64 | UInt32 | UInt32 | UInt32
UInt16 | Int64 | Int32 | Int32 | Int32 | UInt64 | UInt32 | UInt16 | UInt16
UInt8 | Int64 | Int32 | Int16 | Int16 | UInt64 | UInt32 | UInt16 | UInt8


# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, `test_union_upcast_types` test function is added showing the error is solved in the issue.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No.