### PR TITLE
Remove temporal to kernels_arrow

### DIFF
--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -68,14 +68,15 @@ use kernels::{
     bitwise_xor, bitwise_xor_scalar,
 };
 use kernels_arrow::{
-    add_decimal_dyn_scalar, add_dyn_decimal, divide_decimal_dyn_scalar,
-    divide_dyn_opt_decimal, is_distinct_from, is_distinct_from_bool,
-    is_distinct_from_decimal, is_distinct_from_f32, is_distinct_from_f64,
-    is_distinct_from_null, is_distinct_from_utf8, is_not_distinct_from,
-    is_not_distinct_from_bool, is_not_distinct_from_decimal, is_not_distinct_from_f32,
-    is_not_distinct_from_f64, is_not_distinct_from_null, is_not_distinct_from_utf8,
-    modulus_decimal_dyn_scalar, modulus_dyn_decimal, multiply_decimal_dyn_scalar,
-    multiply_dyn_decimal, subtract_decimal_dyn_scalar, subtract_dyn_decimal,
+    add_decimal_dyn_scalar, add_dyn_decimal, add_dyn_temporal, add_dyn_temporal_scalar,
+    divide_decimal_dyn_scalar, divide_dyn_opt_decimal, is_distinct_from,
+    is_distinct_from_bool, is_distinct_from_decimal, is_distinct_from_f32,
+    is_distinct_from_f64, is_distinct_from_null, is_distinct_from_utf8,
+    is_not_distinct_from, is_not_distinct_from_bool, is_not_distinct_from_decimal,
+    is_not_distinct_from_f32, is_not_distinct_from_f64, is_not_distinct_from_null,
+    is_not_distinct_from_utf8, modulus_decimal_dyn_scalar, modulus_dyn_decimal,
+    multiply_decimal_dyn_scalar, multiply_dyn_decimal, subtract_decimal_dyn_scalar,
+    subtract_dyn_decimal, subtract_dyn_temporal, subtract_dyn_temporal_scalar,
 };
 
 use arrow::datatypes::{DataType, Schema, TimeUnit};
@@ -1266,10 +1267,39 @@ macro_rules! sub_timestamp_macro {
         Arc::new(ret) as ArrayRef
     }};
 }
+
+pub fn resolve_temporal_op(
+    lhs: &ArrayRef,
+    sign: i32,
+    rhs: &ArrayRef,
+) -> Result<ArrayRef> {
+    match sign {
+        1 => add_dyn_temporal(lhs, rhs),
+        -1 => subtract_dyn_temporal(lhs, rhs),
+        other => Err(DataFusionError::Internal(format!(
+            "Undefined operation for temporal types {other}"
+        ))),
+    }
+}
+
+pub fn resolve_temporal_op_scalar(
+    lhs: &ArrayRef,
+    sign: i32,
+    rhs: &ScalarValue,
+) -> Result<ColumnarValue> {
+    match sign {
+        1 => add_dyn_temporal_scalar(lhs, rhs),
+        -1 => subtract_dyn_temporal_scalar(lhs, rhs),
+        other => Err(DataFusionError::Internal(format!(
+            "Undefined operation for temporal types {other}"
+        ))),
+    }
+}
+
 /// This function handles the Timestamp - Timestamp operations,
 /// where the first one is an array, and the second one is a scalar,
 /// hence the result is also an array.
-pub fn ts_scalar_ts_op(array: ArrayRef, scalar: &ScalarValue) -> Result<ColumnarValue> {
+pub fn ts_scalar_ts_op(array: &ArrayRef, scalar: &ScalarValue) -> Result<ColumnarValue> {
     let ret = match (array.data_type(), scalar) {
         (
             DataType::Timestamp(TimeUnit::Second, opt_tz_lhs),
@@ -1364,7 +1394,7 @@ macro_rules! sub_timestamp_interval_macro {
 /// where the first one is an array, and the second one is a scalar,
 /// hence the result is also an array.
 pub fn ts_scalar_interval_op(
-    array: ArrayRef,
+    array: &ArrayRef,
     sign: i32,
     scalar: &ScalarValue,
 ) -> Result<ColumnarValue> {
@@ -1448,7 +1478,7 @@ macro_rules! sub_interval_cross_macro {
 /// where the first one is an array, and the second one is a scalar,
 /// hence the result is also an interval array.
 pub fn interval_scalar_interval_op(
-    array: ArrayRef,
+    array: &ArrayRef,
     sign: i32,
     scalar: &ScalarValue,
 ) -> Result<ColumnarValue> {

--- a/datafusion/physical-expr/src/expressions/datetime.rs
+++ b/datafusion/physical-expr/src/expressions/datetime.rs
@@ -19,13 +19,9 @@ use crate::intervals::cp_solver::{propagate_arithmetic, propagate_comparison};
 use crate::intervals::{apply_operator, Interval};
 use crate::physical_expr::down_cast_any_ref;
 use crate::PhysicalExpr;
-use arrow::array::{Array, ArrayRef};
-use arrow::compute::try_unary;
-use arrow::datatypes::{DataType, Date32Type, Date64Type, Schema};
+use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
 
-use datafusion_common::cast::*;
-use datafusion_common::scalar::*;
 use datafusion_common::Result;
 use datafusion_common::{DataFusionError, ScalarValue};
 use datafusion_expr::type_coercion::binary::coerce_types;
@@ -34,10 +30,7 @@ use std::any::Any;
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
-use super::binary::{
-    interval_array_op, interval_scalar_interval_op, ts_array_op, ts_interval_array_op,
-    ts_scalar_interval_op, ts_scalar_ts_op,
-};
+use super::binary::{resolve_temporal_op, resolve_temporal_op_scalar};
 
 /// Perform DATE/TIME/TIMESTAMP +/ INTERVAL math
 #[derive(Debug)]
@@ -151,13 +144,18 @@ impl PhysicalExpr for DateTimeIntervalExpr {
                     operand_lhs.sub(&operand_rhs)?
                 }))
             }
-            (ColumnarValue::Array(array_lhs), ColumnarValue::Scalar(operand_rhs)) => {
-                evaluate_temporal_array(array_lhs, sign, &operand_rhs)
+            // This function evaluates temporal array vs scalar operations, such as timestamp - timestamp,
+            // interval + interval, timestamp + interval, and interval + timestamp. It takes two arrays as input
+            // and an integer sign representing the operation (+1 for addition and -1 for subtraction).
+            (ColumnarValue::Array(array_lhs), ColumnarValue::Scalar(array_rhs)) => {
+                resolve_temporal_op_scalar(&array_lhs, sign, &array_rhs)
             }
-
-            (ColumnarValue::Array(array_lhs), ColumnarValue::Array(array_rhs)) => {
-                evaluate_temporal_arrays(&array_lhs, sign, &array_rhs)
-            }
+            // This function evaluates temporal array operations, such as timestamp - timestamp, interval + interval,
+            // timestamp + interval, and interval + timestamp. It takes two arrays as input and an integer sign representing
+            // the operation (+1 for addition and -1 for subtraction).
+            (ColumnarValue::Array(array_lhs), ColumnarValue::Array(array_rhs)) => Ok(
+                ColumnarValue::Array(resolve_temporal_op(&array_lhs, sign, &array_rhs)?),
+            ),
             (_, _) => {
                 let msg = "If RHS of the operation is an array, then LHS also must be";
                 Err(DataFusionError::Internal(msg.to_string()))
@@ -225,82 +223,6 @@ impl PartialEq<dyn Any> for DateTimeIntervalExpr {
             .map(|x| self.lhs.eq(&x.lhs) && self.op == x.op && self.rhs.eq(&x.rhs))
             .unwrap_or(false)
     }
-}
-
-pub fn evaluate_temporal_array(
-    array: ArrayRef,
-    sign: i32,
-    scalar: &ScalarValue,
-) -> Result<ColumnarValue> {
-    match (array.data_type(), scalar.get_datatype()) {
-        // Date +- Interval
-        (DataType::Date32, DataType::Interval(_)) => {
-            let array = as_date32_array(&array)?;
-            let ret = Arc::new(try_unary::<Date32Type, _, Date32Type>(array, |days| {
-                Ok(date32_add(days, scalar, sign)?)
-            })?) as ArrayRef;
-            Ok(ColumnarValue::Array(ret))
-        }
-        (DataType::Date64, DataType::Interval(_)) => {
-            let array = as_date64_array(&array)?;
-            let ret = Arc::new(try_unary::<Date64Type, _, Date64Type>(array, |ms| {
-                Ok(date64_add(ms, scalar, sign)?)
-            })?) as ArrayRef;
-            Ok(ColumnarValue::Array(ret))
-        }
-        // Timestamp - Timestamp
-        (DataType::Timestamp(_, _), DataType::Timestamp(_, _)) if sign == -1 => {
-            ts_scalar_ts_op(array, scalar)
-        }
-        // Interval +- Interval
-        (DataType::Interval(_), DataType::Interval(_)) => {
-            interval_scalar_interval_op(array, sign, scalar)
-        }
-        // Timestamp +- Interval
-        (DataType::Timestamp(_, _), DataType::Interval(_)) => {
-            ts_scalar_interval_op(array, sign, scalar)
-        }
-        (_, _) => Err(DataFusionError::Execution(format!(
-            "Invalid lhs type for DateIntervalExpr: {}",
-            array.data_type()
-        )))?,
-    }
-}
-
-// This function evaluates temporal array operations, such as timestamp - timestamp, interval + interval,
-// timestamp + interval, and interval + timestamp. It takes two arrays as input and an integer sign representing
-// the operation (+1 for addition and -1 for subtraction). It returns a ColumnarValue as output, which can hold
-// either a scalar or an array.
-pub fn evaluate_temporal_arrays(
-    array_lhs: &ArrayRef,
-    sign: i32,
-    array_rhs: &ArrayRef,
-) -> Result<ColumnarValue> {
-    let ret = match (array_lhs.data_type(), array_rhs.data_type()) {
-        // Timestamp - Timestamp operations, operands of only the same types are supported.
-        (DataType::Timestamp(_, _), DataType::Timestamp(_, _)) => {
-            ts_array_op(array_lhs, array_rhs)?
-        }
-        // Interval (+ , -) Interval operations
-        (DataType::Interval(_), DataType::Interval(_)) => {
-            interval_array_op(array_lhs, array_rhs, sign)?
-        }
-        // Timestamp (+ , -) Interval and Interval + Timestamp operations
-        // Interval - Timestamp operation is not rational hence not supported
-        (DataType::Timestamp(_, _), DataType::Interval(_)) => {
-            ts_interval_array_op(array_lhs, sign, array_rhs)?
-        }
-        (DataType::Interval(_), DataType::Timestamp(_, _)) if sign == 1 => {
-            ts_interval_array_op(array_rhs, sign, array_lhs)?
-        }
-        (_, _) => Err(DataFusionError::Execution(format!(
-            "Invalid array types for DateIntervalExpr: {} {} {}",
-            array_lhs.data_type(),
-            sign,
-            array_rhs.data_type()
-        )))?,
-    };
-    Ok(ColumnarValue::Array(ret))
 }
 
 #[cfg(test)]
@@ -707,7 +629,7 @@ mod tests {
     }
 
     // In this test, ArrayRef of one element arrays is evaluated with some ScalarValues,
-    // aiming that evaluate_temporal_array function is working properly and shows the same
+    // aiming that resolve_temporal_op_scalar function is working properly and shows the same
     // behavior with ScalarValue arithmetic.
     fn experiment(
         timestamp_scalar: ScalarValue,
@@ -718,7 +640,7 @@ mod tests {
 
         // timestamp + interval
         if let ColumnarValue::Array(res1) =
-            evaluate_temporal_array(timestamp_array.clone(), 1, &interval_scalar)?
+            resolve_temporal_op_scalar(&timestamp_array, 1, &interval_scalar)?
         {
             let res2 = timestamp_scalar.add(&interval_scalar)?.to_array();
             assert_eq!(
@@ -730,7 +652,7 @@ mod tests {
 
         // timestamp - interval
         if let ColumnarValue::Array(res1) =
-            evaluate_temporal_array(timestamp_array.clone(), -1, &interval_scalar)?
+            resolve_temporal_op_scalar(&timestamp_array, -1, &interval_scalar)?
         {
             let res2 = timestamp_scalar.sub(&interval_scalar)?.to_array();
             assert_eq!(
@@ -742,7 +664,7 @@ mod tests {
 
         // timestamp - timestamp
         if let ColumnarValue::Array(res1) =
-            evaluate_temporal_array(timestamp_array.clone(), -1, &timestamp_scalar)?
+            resolve_temporal_op_scalar(&timestamp_array, -1, &timestamp_scalar)?
         {
             let res2 = timestamp_scalar.sub(&timestamp_scalar)?.to_array();
             assert_eq!(
@@ -754,7 +676,7 @@ mod tests {
 
         // interval - interval
         if let ColumnarValue::Array(res1) =
-            evaluate_temporal_array(interval_array.clone(), -1, &interval_scalar)?
+            resolve_temporal_op_scalar(&interval_array, -1, &interval_scalar)?
         {
             let res2 = interval_scalar.sub(&interval_scalar)?.to_array();
             assert_eq!(
@@ -766,7 +688,7 @@ mod tests {
 
         // interval + interval
         if let ColumnarValue::Array(res1) =
-            evaluate_temporal_array(interval_array, 1, &interval_scalar)?
+            resolve_temporal_op_scalar(&interval_array, 1, &interval_scalar)?
         {
             let res2 = interval_scalar.add(&interval_scalar)?.to_array();
             assert_eq!(


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5704.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Temporal arithmetic code will be moved to arrow-rs eventually. For this purpose, this PR is an intermediate step that facilitates the process (the same pattern used for other removals).

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

In datetime.rs, the `evaluate()` function calls the binary.rs function `resolve_temporal_op()` and `resolve_temporal_op_scalar()`, according to type of the second value, Array or Scalar. It can access the **add/sub_dyn...()** functions in kernels_arrow.rs (the functions that will be moved to arrow-rs deployed here until arrow-rs changes happen)

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, with existing tests.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->