### PR TITLE
Filter pushdown through cross join

### DIFF
--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -780,52 +780,7 @@ impl LogicalPlan {
             LogicalPlan::CrossJoin(_) => {
                 let left = inputs[0].clone();
                 let right = inputs[1].clone();
-                if expr.is_empty() {
-                    // If expr is empty, construct cross join from children
-                    LogicalPlanBuilder::from(left).cross_join(right)?.build()
-                } else {
-                    let exprs = expr
-                        .iter()
-                        .flat_map(|expr| split_conjunction(expr))
-                        .collect::<Vec<_>>();
-                    let mut new_on: Vec<(Expr, Expr)> = vec![];
-                    let mut new_filters = vec![];
-                    for expr in exprs {
-                        // SimplifyExpression rule may add alias to the equi_expr.
-                        let unalias_expr = expr.clone().unalias();
-                        if let Expr::BinaryExpr(BinaryExpr {
-                            left,
-                            op: Operator::Eq,
-                            right,
-                        }) = unalias_expr
-                        {
-                            new_on.push((*left, *right));
-                        } else {
-                            new_filters.push(expr.clone());
-                        }
-                    }
-                    let filter = if new_filters.is_empty() {
-                        None
-                    } else {
-                        Some(new_filters.into_iter().reduce(Expr::and).unwrap())
-                    };
-                    let join_schema = build_join_schema(
-                        left.schema(),
-                        right.schema(),
-                        &JoinType::Inner,
-                    )?;
-                    // predicate is given
-                    Ok(LogicalPlan::Join(Join {
-                        left: Arc::new(left),
-                        right: Arc::new(right),
-                        join_type: JoinType::Inner,
-                        join_constraint: JoinConstraint::On,
-                        on: new_on,
-                        filter,
-                        schema: DFSchemaRef::new(join_schema),
-                        null_equals_null: true,
-                    }))
-                }
+                LogicalPlanBuilder::from(left).cross_join(right)?.build()
             }
             LogicalPlan::Subquery(Subquery {
                 outer_ref_columns, ..

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -857,7 +857,7 @@ impl OptimizerRule for PushDownFilter {
                     left,
                     right,
                     vec![],
-                    false,
+                    true,
                 )?
             }
             LogicalPlan::TableScan(scan) => {

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -19,18 +19,19 @@ use crate::optimizer::ApplyOrder;
 use crate::{OptimizerConfig, OptimizerRule};
 use datafusion_common::tree_node::{Transformed, TreeNode, VisitRecursion};
 use datafusion_common::{
-    internal_err, plan_datafusion_err, Column, DFSchema, DataFusionError, Result,
+    internal_err, plan_datafusion_err, Column, DFSchema, DFSchemaRef, DataFusionError,
+    JoinConstraint, Result,
 };
 use datafusion_expr::expr::Alias;
 use datafusion_expr::utils::{conjunction, split_conjunction, split_conjunction_owned};
-use datafusion_expr::Volatility;
 use datafusion_expr::{
     and,
     expr_rewriter::replace_col,
     logical_plan::{CrossJoin, Join, JoinType, LogicalPlan, TableScan, Union},
-    or, BinaryExpr, Expr, Filter, Operator, ScalarFunctionDefinition,
+    or, BinaryExpr, Expr, Filter, LogicalPlanBuilder, Operator, ScalarFunctionDefinition,
     TableProviderFilterPushDown,
 };
+use datafusion_expr::{build_join_schema, Volatility};
 use itertools::Itertools;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -848,17 +849,23 @@ impl OptimizerRule for PushDownFilter {
                     None => return Ok(None),
                 }
             }
-            LogicalPlan::CrossJoin(CrossJoin { left, right, .. }) => {
+            LogicalPlan::CrossJoin(cross_join) => {
                 let predicates = split_conjunction_owned(filter.predicate.clone());
-                push_down_all_join(
+                let join = convert_cross_join_to_inner_join(cross_join.clone())?;
+                let join_plan = LogicalPlan::Join(join);
+                let inputs = join_plan.inputs();
+                let left = inputs[0];
+                let right = inputs[1];
+                let plan = push_down_all_join(
                     predicates,
                     vec![],
-                    &filter.input,
+                    &join_plan,
                     left,
                     right,
                     vec![],
                     true,
-                )?
+                )?;
+                convert_to_cross_join_if_beneficial(plan)?
             }
             LogicalPlan::TableScan(scan) => {
                 let filter_predicates = split_conjunction(&filter.predicate);
@@ -953,6 +960,36 @@ impl PushDownFilter {
     pub fn new() -> Self {
         Self {}
     }
+}
+
+/// Convert cross join to join by pushing down filter predicate to the join condition
+fn convert_cross_join_to_inner_join(cross_join: CrossJoin) -> Result<Join> {
+    let CrossJoin { left, right, .. } = cross_join;
+    let join_schema = build_join_schema(left.schema(), right.schema(), &JoinType::Inner)?;
+    // predicate is given
+    Ok(Join {
+        left,
+        right,
+        join_type: JoinType::Inner,
+        join_constraint: JoinConstraint::On,
+        on: vec![],
+        filter: None,
+        schema: DFSchemaRef::new(join_schema),
+        null_equals_null: true,
+    })
+}
+
+/// Converts the inner join with empty equality predicate and empty filter condition to the cross join
+fn convert_to_cross_join_if_beneficial(plan: LogicalPlan) -> Result<LogicalPlan> {
+    if let LogicalPlan::Join(join) = &plan {
+        // Can be converted back to cross join
+        if join.on.is_empty() && join.filter.is_none() {
+            return LogicalPlanBuilder::from(join.left.as_ref().clone())
+                .cross_join(join.right.as_ref().clone())?
+                .build();
+        }
+    }
+    Ok(plan)
 }
 
 /// replaces columns by its name on the projection.
@@ -2665,14 +2702,12 @@ Projection: a, b
             .cross_join(right)?
             .filter(filter)?
             .build()?;
-
         let expected = "\
-        Filter: test.a = d AND test.b > UInt32(1) OR test.b = e AND test.c < UInt32(10)\
-        \n  CrossJoin:\
-        \n    Projection: test.a, test.b, test.c\
-        \n      TableScan: test, full_filters=[test.b > UInt32(1) OR test.c < UInt32(10)]\
-        \n    Projection: test1.a AS d, test1.a AS e\
-        \n      TableScan: test1";
+        Inner Join:  Filter: test.a = d AND test.b > UInt32(1) OR test.b = e AND test.c < UInt32(10)\
+        \n  Projection: test.a, test.b, test.c\
+        \n    TableScan: test, full_filters=[test.b > UInt32(1) OR test.c < UInt32(10)]\
+        \n  Projection: test1.a AS d, test1.a AS e\
+        \n    TableScan: test1";
         assert_optimized_plan_eq_with_rewrite_predicate(&plan, expected)?;
 
         // Originally global state which can help to avoid duplicate Filters been generated and pushed down.

--- a/datafusion/sqllogictest/test_files/joins.slt
+++ b/datafusion/sqllogictest/test_files/joins.slt
@@ -3483,7 +3483,6 @@ NestedLoopJoinExec: join_type=Inner, filter=a@0 > a@1
 ----CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_ordering=[a@1 ASC, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST], has_header=true
 --CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_ordering=[a@1 ASC, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST], has_header=true
 
-
 ####
 # Config teardown
 ####

--- a/datafusion/sqllogictest/test_files/joins.slt
+++ b/datafusion/sqllogictest/test_files/joins.slt
@@ -3466,6 +3466,24 @@ SortPreservingMergeExec: [a@0 ASC]
 ----------------------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
 ------------------------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a, b], output_ordering=[a@0 ASC, b@1 ASC NULLS LAST], has_header=true
 
+query TT
+EXPLAIN SELECT *
+FROM annotated_data as l, annotated_data as r
+WHERE l.a > r.a
+----
+logical_plan
+Inner Join:  Filter: l.a > r.a
+--SubqueryAlias: l
+----TableScan: annotated_data projection=[a0, a, b, c, d]
+--SubqueryAlias: r
+----TableScan: annotated_data projection=[a0, a, b, c, d]
+physical_plan
+NestedLoopJoinExec: join_type=Inner, filter=a@0 > a@1
+--RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+----CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_ordering=[a@1 ASC, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST], has_header=true
+--CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_ordering=[a@1 ASC, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST], has_header=true
+
+
 ####
 # Config teardown
 ####


### PR DESCRIPTION
<!--
Before opening a PR. Make sure following points are double-checked
-- Make sure `cargo fmt` is done.
-- Make sure `bash dev/rust_lint.sh` successfully runs.
-- Make sure `cargo test` passes from all tests.
-- Make sure there are wide-ranging unit tests, integration tests, end-to-end tests for the added functionality.
-- Make sure there is no merge conflict with target branch.
-- If there are sections in the code, that can be written as function do so
     Especially, if these sections are 
      - occur multiple times,
      - line number is more than > 20 approximately.
-- The code added doesn't contain unnecessary `.clone`s.
-- The code added doesn't contain naked `unwrap`s.
-- Make sure imports are consistent. Imports should be in following order
    - Standart library imports (alphabetically ordered within this group)
    - Arrow/ Datafusion imports (alphabetically ordered within this group)
    - #rd Party libraries (alphabetically ordered within this group)
    where each group is seperated by an empty line.
    
-- Inspect your attributes to what needs to be public, do not expose something if it is not used elsewhere.
-- Make sure that the docstrings of the newly added code blocks are not missing.
-- Read through comments whether they are clear, and grammatically correct.
-- Look for whether for loops can be re-written as iterator. Be pro-functional style.
-- Do not use short names such as `res`, `elem`, instead use `result`, `item`, etc.
-- For short and common functions use namespace with it to be explicit.
   (such as instead of `min`, `max`, use `std::cmp::min`, `std::cmp::max` etc.)
-- Add necessary license notice for the added code that will remain in the Synnada repo.
-- Make sure the PR body is understandable and summarizes the topic well.
-- You can use CHATGPT to convert code to idimatic style, to generate documentation.
-->
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change
Current filters are not pushed down to the cross join (equality predicates are pushed down). For this reason we generate following plan for the query 
```sql
SELECT *
FROM annotated_data as l, annotated_data as r
WHERE l.a > r.a
```

```sql
FilterExec: filter=a@0 > a@1
--CrossJoinExec: 
----RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_ordering=[a@1 ASC, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST], has_header=true
----CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_ordering=[a@1 ASC, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST], has_header=true
```

However, if we were to pushdown filter into CrossJoin (by converting it into inner join with filter condition ) we could have produced following plan

```sql
NestedLoopJoinExec: join_type=Inner, filter=a@0 > a@1
--RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
----CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_ordering=[a@1 ASC, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST], has_header=true
--CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/window_2.csv]]}, projection=[a0, a, b, c, d], output_ordering=[a@1 ASC, b@2 ASC NULLS LAST, c@3 ASC NULLS LAST], has_header=true
```

which would be more memory efficient especially in large tables. This PR adds this support

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
